### PR TITLE
Adding support for model column :time

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ model_name:
       # Choose one of the following
       type: datetime
       type: date
+      type: time
       type: decimal
       type: integer
       type: string

--- a/lib/model_configuration/attribute/factory_declaration.rb
+++ b/lib/model_configuration/attribute/factory_declaration.rb
@@ -14,7 +14,7 @@ private
 
   def data_for_attribute
     case attribute.type
-    when "datetime", "date"
+    when "datetime", "date", "time"
       date_data
     when "decimal", "integer"
       number_data

--- a/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
+++ b/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
@@ -8,19 +8,11 @@ describe ModelConfiguration::Attribute::FactoryDeclaration do
     let(:name)      { "field_name" }
     let(:options)   { {type: type} }
 
-    context "type is 'date'" do
-      let(:type) { "date" }
-      it { should eq("field_name { 5.days.from_now }") }
-    end
-
-    context "type is 'datetime'" do
-      let(:type) { "datetime" }
-      it { should eq("field_name { 5.days.from_now }") }
-    end
-
-    context "type is 'time'" do
-      let(:type) { "time" }
-      it { should eq("field_name { 5.days.from_now }") }
+    [:date, :datetime, :time].each do |type|
+      context "type is '#{type}'" do
+        let(:type) { type.to_s }
+        it { should eq("field_name { 5.days.from_now }") }
+      end
     end
 
     context "type is 'decimal'" do

--- a/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
+++ b/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
@@ -18,6 +18,11 @@ describe ModelConfiguration::Attribute::FactoryDeclaration do
       it { should eq("field_name { 5.days.from_now }") }
     end
 
+    context "type is 'time'" do
+      let(:type) { "time" }
+      it { should eq("field_name { 5.days.from_now }") }
+    end
+
     context "type is 'decimal'" do
       let(:type) { "decimal" }
       it { should eq("field_name { rand(9999) }") }


### PR DESCRIPTION
Now you can do:

```
shift:
  attributes:
    start_at:
      type: "time"
      validates:
        presence: true
    end_at:
      type: "time"
      validates:
        presence: true
```