### PR TITLE
Add in support for date_picker arg

### DIFF
--- a/lib/model_configuration/attribute.rb
+++ b/lib/model_configuration/attribute.rb
@@ -5,7 +5,7 @@ class ModelConfiguration
 
     def initialize(model_configuration, name, properties)
       @model_configuration = model_configuration
-      @name = name
+      @name = name.to_s
       @properties = properties
     end
 
@@ -32,7 +32,7 @@ class ModelConfiguration
     end
 
     def type
-      properties[:type]
+      properties[:type].to_s
     end
 
   # Views

--- a/lib/model_configuration/attribute/input_implementation.rb
+++ b/lib/model_configuration/attribute/input_implementation.rb
@@ -21,6 +21,13 @@ private
   def attribute_options
     options = {}
 
+    # datetimes and dates should use the date_picker input type
+    #
+    # f.input :attribute_name, as: :date_picker
+    if attribute.type.in?(["datetime", "date"])
+      options[:as] = ":date_picker"
+    end
+
     # For inclusion validations, we should ensure that the required values are passed as a
     # collection to the input. EG:
     #

--- a/spec/lib/model_configuration/attribute/input_implementation_spec.rb
+++ b/spec/lib/model_configuration/attribute/input_implementation_spec.rb
@@ -11,6 +11,16 @@ describe ModelConfiguration::Attribute::InputImplementation do
     subject { input_implementation.to_s(input_options) }
     let(:input_options) { {} }
 
+    describe "using as: :date_picker" do
+      [:datetime, :date].each do |attribute_type|
+        context "when type is #{attribute_type}" do
+          let(:options) { {type: attribute_type} }
+
+          it { should eq("f.input :attribute_name, as: :date_picker") }
+        end
+      end
+    end
+
     describe "providing additional options" do
       let(:input_options) { {my_option: ":jordan_rules"} }
 


### PR DESCRIPTION
This just includes `as: :date_picker` for dates and datetimes. That's the best option we have for those two types in the template.