### PR TITLE
Adding support to models without soft delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ You can specify which attributes should be on your model thusly:
 
 ```yaml
 model_name:
+  soft_delete: false # true by default
+  skip_ui: false # true by default (only used by scaffold generator)
   attributes:
     attribute_name:
       # Set to false if you don't want this attribute to be represented on the index

--- a/frontier_generators.gemspec
+++ b/frontier_generators.gemspec
@@ -1,18 +1,18 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+# stub: frontier_generators 0.5.0 ruby lib
 
 Gem::Specification.new do |s|
-  s.name        = "frontier_generators"
-  s.version     = "0.5.0"
-  s.authors     = ["Jordan Maguire"]
-  s.email       = ["jordan@thefrontiergroup.com.au"]
-  s.homepage    = "https://github.com/thefrontiergroup/frontier_generators"
-  s.summary     = "Comprehensive generators for CRUD"
-  s.description = <<-EOF
-    Use in conjunction with the Rails Template (https://github.com/thefrontiergroup/rails-template)
-    to quickly scaffold usable admin interfaces for models.
-  EOF
+  s.name = "frontier_generators"
+  s.version = "0.5.0"
 
-  s.files         = Dir['README.md', 'lib/**/{*,.[a-z]*}']
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
+  s.authors = ["Jordan Maguire"]
+  s.date = "2015-06-26"
+  s.description = "    Use in conjunction with the Rails Template (https://github.com/thefrontiergroup/rails-template)\n    to quickly scaffold usable admin interfaces for models.\n"
+  s.email = ["jordan@thefrontiergroup.com.au"]
+  s.files = ["README.md", "lib/generators", "lib/generators/frontier_controller", "lib/generators/frontier_controller/USAGE", "lib/generators/frontier_controller/frontier_controller_generator.rb", "lib/generators/frontier_controller/templates", "lib/generators/frontier_controller/templates/controller.rb", "lib/generators/frontier_controller/templates/controller_spec.rb", "lib/generators/frontier_crud_views", "lib/generators/frontier_crud_views/USAGE", "lib/generators/frontier_crud_views/frontier_crud_views_generator.rb", "lib/generators/frontier_crud_views/templates", "lib/generators/frontier_crud_views/templates/_form.html.haml", "lib/generators/frontier_crud_views/templates/create_spec.rb", "lib/generators/frontier_crud_views/templates/delete_spec.rb", "lib/generators/frontier_crud_views/templates/edit.html.haml", "lib/generators/frontier_crud_views/templates/feature_attributes_support.rb", "lib/generators/frontier_crud_views/templates/index.html.haml", "lib/generators/frontier_crud_views/templates/index_spec.rb", "lib/generators/frontier_crud_views/templates/new.html.haml", "lib/generators/frontier_crud_views/templates/update_spec.rb", "lib/generators/frontier_model", "lib/generators/frontier_model/USAGE", "lib/generators/frontier_model/frontier_model_generator.rb", "lib/generators/frontier_model/templates", "lib/generators/frontier_model/templates/factory.rb", "lib/generators/frontier_model/templates/model.rb", "lib/generators/frontier_model/templates/model_spec.rb", "lib/generators/frontier_policy", "lib/generators/frontier_policy/USAGE", "lib/generators/frontier_policy/frontier_policy_generator.rb", "lib/generators/frontier_policy/templates", "lib/generators/frontier_policy/templates/policy.rb", "lib/generators/frontier_policy/templates/policy_spec.rb", "lib/generators/frontier_route", "lib/generators/frontier_route/USAGE", "lib/generators/frontier_route/frontier_route_generator.rb", "lib/generators/frontier_route/lib", "lib/generators/frontier_route/lib/namespace.rb", "lib/generators/frontier_route/lib/resource.rb", "lib/generators/frontier_scaffold", "lib/generators/frontier_scaffold/USAGE", "lib/generators/frontier_scaffold/frontier_scaffold_generator.rb", "lib/generators/frontier_seed", "lib/generators/frontier_seed/frontier_seed_generator.rb", "lib/generators/frontier_seed/templates", "lib/generators/frontier_seed/templates/seed.rake", "lib/model_configuration", "lib/model_configuration/association", "lib/model_configuration/association.rb", "lib/model_configuration/association/factory_declaration.rb", "lib/model_configuration/association/model_implementation.rb", "lib/model_configuration/attribute", "lib/model_configuration/attribute.rb", "lib/model_configuration/attribute/constant.rb", "lib/model_configuration/attribute/factory.rb", "lib/model_configuration/attribute/factory_declaration.rb", "lib/model_configuration/attribute/input_implementation.rb", "lib/model_configuration/attribute/migration_component.rb", "lib/model_configuration/attribute/validation", "lib/model_configuration/attribute/validation.rb", "lib/model_configuration/attribute/validation/numericality.rb", "lib/model_configuration/model_configuration.rb", "lib/model_configuration/url_builder.rb"]
+  s.homepage = "https://github.com/thefrontiergroup/frontier_generators"
+  s.rubygems_version = "2.4.6"
+  s.summary = "Comprehensive generators for CRUD"
 end

--- a/frontier_generators.gemspec
+++ b/frontier_generators.gemspec
@@ -1,18 +1,18 @@
 # -*- encoding: utf-8 -*-
-# stub: frontier_generators 0.5.0 ruby lib
+$:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
-  s.name = "frontier_generators"
-  s.version = "0.5.0"
+  s.name        = "frontier_generators"
+  s.version     = "0.5.0"
+  s.authors     = ["Jordan Maguire"]
+  s.email       = ["jordan@thefrontiergroup.com.au"]
+  s.homepage    = "https://github.com/thefrontiergroup/frontier_generators"
+  s.summary     = "Comprehensive generators for CRUD"
+  s.description = <<-EOF
+    Use in conjunction with the Rails Template (https://github.com/thefrontiergroup/rails-template)
+    to quickly scaffold usable admin interfaces for models.
+  EOF
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.files         = Dir['README.md', 'lib/**/{*,.[a-z]*}']
   s.require_paths = ["lib"]
-  s.authors = ["Jordan Maguire"]
-  s.date = "2015-06-26"
-  s.description = "    Use in conjunction with the Rails Template (https://github.com/thefrontiergroup/rails-template)\n    to quickly scaffold usable admin interfaces for models.\n"
-  s.email = ["jordan@thefrontiergroup.com.au"]
-  s.files = ["README.md", "lib/generators", "lib/generators/frontier_controller", "lib/generators/frontier_controller/USAGE", "lib/generators/frontier_controller/frontier_controller_generator.rb", "lib/generators/frontier_controller/templates", "lib/generators/frontier_controller/templates/controller.rb", "lib/generators/frontier_controller/templates/controller_spec.rb", "lib/generators/frontier_crud_views", "lib/generators/frontier_crud_views/USAGE", "lib/generators/frontier_crud_views/frontier_crud_views_generator.rb", "lib/generators/frontier_crud_views/templates", "lib/generators/frontier_crud_views/templates/_form.html.haml", "lib/generators/frontier_crud_views/templates/create_spec.rb", "lib/generators/frontier_crud_views/templates/delete_spec.rb", "lib/generators/frontier_crud_views/templates/edit.html.haml", "lib/generators/frontier_crud_views/templates/feature_attributes_support.rb", "lib/generators/frontier_crud_views/templates/index.html.haml", "lib/generators/frontier_crud_views/templates/index_spec.rb", "lib/generators/frontier_crud_views/templates/new.html.haml", "lib/generators/frontier_crud_views/templates/update_spec.rb", "lib/generators/frontier_model", "lib/generators/frontier_model/USAGE", "lib/generators/frontier_model/frontier_model_generator.rb", "lib/generators/frontier_model/templates", "lib/generators/frontier_model/templates/factory.rb", "lib/generators/frontier_model/templates/model.rb", "lib/generators/frontier_model/templates/model_spec.rb", "lib/generators/frontier_policy", "lib/generators/frontier_policy/USAGE", "lib/generators/frontier_policy/frontier_policy_generator.rb", "lib/generators/frontier_policy/templates", "lib/generators/frontier_policy/templates/policy.rb", "lib/generators/frontier_policy/templates/policy_spec.rb", "lib/generators/frontier_route", "lib/generators/frontier_route/USAGE", "lib/generators/frontier_route/frontier_route_generator.rb", "lib/generators/frontier_route/lib", "lib/generators/frontier_route/lib/namespace.rb", "lib/generators/frontier_route/lib/resource.rb", "lib/generators/frontier_scaffold", "lib/generators/frontier_scaffold/USAGE", "lib/generators/frontier_scaffold/frontier_scaffold_generator.rb", "lib/generators/frontier_seed", "lib/generators/frontier_seed/frontier_seed_generator.rb", "lib/generators/frontier_seed/templates", "lib/generators/frontier_seed/templates/seed.rake", "lib/model_configuration", "lib/model_configuration/association", "lib/model_configuration/association.rb", "lib/model_configuration/association/factory_declaration.rb", "lib/model_configuration/association/model_implementation.rb", "lib/model_configuration/attribute", "lib/model_configuration/attribute.rb", "lib/model_configuration/attribute/constant.rb", "lib/model_configuration/attribute/factory.rb", "lib/model_configuration/attribute/factory_declaration.rb", "lib/model_configuration/attribute/input_implementation.rb", "lib/model_configuration/attribute/migration_component.rb", "lib/model_configuration/attribute/validation", "lib/model_configuration/attribute/validation.rb", "lib/model_configuration/attribute/validation/numericality.rb", "lib/model_configuration/model_configuration.rb", "lib/model_configuration/url_builder.rb"]
-  s.homepage = "https://github.com/thefrontiergroup/frontier_generators"
-  s.rubygems_version = "2.4.6"
-  s.summary = "Comprehensive generators for CRUD"
 end

--- a/lib/generators/frontier_model/frontier_model_generator.rb
+++ b/lib/generators/frontier_model/frontier_model_generator.rb
@@ -25,7 +25,9 @@ private
 
   # We include deleted_at for paranoia (soft delete)
   def model_attributes_with_deleted_at
-    (model_attributes << "deleted_at:datetime:index created_at:datetime updated_at:datetime").join(" ")
+    default_columns = ["created_at:datetime", "updated_at:datetime"]
+    default_columns << "deleted_at:datetime:index" if model_configuration.soft_delete
+    (model_attributes + default_columns).join(" ")
   end
 
   # Should be in the format attribute_name:type attribute_name:type

--- a/lib/generators/frontier_model/frontier_model_generator.rb
+++ b/lib/generators/frontier_model/frontier_model_generator.rb
@@ -1,4 +1,5 @@
 require_relative "../../model_configuration/model_configuration"
+require_relative "../../support/migration_string_builder"
 
 class FrontierModelGenerator < Rails::Generators::NamedBase
   source_root File.expand_path('../templates', __FILE__)
@@ -13,27 +14,9 @@ class FrontierModelGenerator < Rails::Generators::NamedBase
       generate("frontier_seed", ARGV[0])
     end
 
-    # EG: CreateDriver name:string contact_number:string
-    generate("migration", "Create#{model_configuration.as_constant} #{model_attributes_with_deleted_at}")
-
+    generate("migration", MigrationStringBuilder.new(model_configuration).to_s)
     template("model.rb", "app/models/#{model_configuration.model_name}.rb")
     template("model_spec.rb", "spec/models/#{model_configuration.model_name}_spec.rb")
     template("factory.rb", "spec/factories/#{model_configuration.model_name.pluralize}.rb")
   end
-
-private
-
-  # We include deleted_at for paranoia (soft delete)
-  def model_attributes_with_deleted_at
-    default_columns = ["created_at:datetime", "updated_at:datetime"]
-    default_columns << "deleted_at:datetime:index" if model_configuration.soft_delete
-    (model_attributes + default_columns).join(" ")
-  end
-
-  # Should be in the format attribute_name:type attribute_name:type
-  # EG: name:string date_of_birth:datetime
-  def model_attributes
-    model_configuration.attributes.collect(&:as_migration_component)
-  end
-
 end

--- a/lib/generators/frontier_model/templates/model.rb
+++ b/lib/generators/frontier_model/templates/model.rb
@@ -1,8 +1,9 @@
 class <%= model_configuration.as_constant %> < ActiveRecord::Base
 
-  # Soft delete - uses deleted_at field
+<% if model_configuration.soft_delete -%>
   acts_as_paranoid
 
+<% end -%>
 <% # The whitespace here is very important, we only want to include a blank line if there are some enums, etc -%>
 <% if model_configuration.attributes.flat_map(&:constants).any? -%>
 <% model_configuration.attributes.flat_map(&:constants).each do |constant| -%>

--- a/lib/generators/frontier_model/templates/model.rb
+++ b/lib/generators/frontier_model/templates/model.rb
@@ -1,6 +1,7 @@
 class <%= model_configuration.as_constant %> < ActiveRecord::Base
 
 <% if model_configuration.soft_delete -%>
+  # Soft delete - uses deleted_at field
   acts_as_paranoid
 
 <% end -%>

--- a/lib/model_configuration/model_configuration.rb
+++ b/lib/model_configuration/model_configuration.rb
@@ -61,15 +61,19 @@ class ModelConfiguration
 private
 
   def assign_attributes_from_model_configuration(hash)
-    @model_name = hash.keys.first
-    @namespaces = hash[@model_name][:namespaces] || []
-    @skip_seeds = hash[@model_name][:skip_seeds] || false
-    @skip_ui    = hash[@model_name][:skip_ui] || false
-    @soft_delete = hash[@model_name][:soft_delete].nil? ? true : hash[@model_name][:soft_delete]
-    @attributes = (hash[@model_name][:attributes] || []).collect do |name, properties|
+    @model_name  = hash.keys.first
+    @namespaces  = hash[@model_name][:namespaces] || []
+    @skip_seeds  = configuration_for(hash[@model_name][:skip_seeds])
+    @skip_ui     = configuration_for(hash[@model_name][:skip_ui])
+    @soft_delete = configuration_for(hash[@model_name][:soft_delete], default: true)
+    @attributes  = (hash[@model_name][:attributes] || []).collect do |name, properties|
       ModelConfiguration::Attribute::Factory.build_attribute_or_association(self, name, properties)
     end
     # TODO: Assert validity of attributes
     @url_builder = ModelConfiguration::UrlBuilder.new(self)
+  end
+
+  def configuration_for(attr, options={ default: false })
+    attr.nil? ? options[:default] : attr
   end
 end

--- a/lib/model_configuration/model_configuration.rb
+++ b/lib/model_configuration/model_configuration.rb
@@ -4,11 +4,14 @@ require_relative "url_builder.rb"
 
 class ModelConfiguration
 
-  attr_reader :model_name, :namespaces, :attributes, :skip_seeds, :skip_ui, :url_builder
+  attr_reader :model_name, :namespaces, :attributes, :skip_seeds, :skip_ui, :url_builder, :soft_delete
 
   # Example YAML:
-  #   drive:
-  #     namespace: "admin"
+  #   driver:
+  #     namespaces: "admin"
+  #     soft_delete: false
+  #     skip_ui: false
+  #     skip_seeds: false
   #     attributes:
   #       name:
   #         type: "string"
@@ -62,11 +65,11 @@ private
     @namespaces = hash[@model_name][:namespaces] || []
     @skip_seeds = hash[@model_name][:skip_seeds] || false
     @skip_ui    = hash[@model_name][:skip_ui] || false
+    @soft_delete = hash[@model_name][:soft_delete].nil? ? true : hash[@model_name][:soft_delete]
     @attributes = (hash[@model_name][:attributes] || []).collect do |name, properties|
       ModelConfiguration::Attribute::Factory.build_attribute_or_association(self, name, properties)
     end
     # TODO: Assert validity of attributes
     @url_builder = ModelConfiguration::UrlBuilder.new(self)
   end
-
 end

--- a/lib/model_configuration/model_configuration.rb
+++ b/lib/model_configuration/model_configuration.rb
@@ -73,7 +73,7 @@ private
     @url_builder = ModelConfiguration::UrlBuilder.new(self)
   end
 
-  def configuration_for(attr, options={ default: false })
-    attr.nil? ? options[:default] : attr
+  def configuration_for(attribute, options={ default: false })
+    attribute.nil? ? options[:default] : attribute
   end
 end

--- a/lib/support/migration_string_builder.rb
+++ b/lib/support/migration_string_builder.rb
@@ -1,0 +1,26 @@
+class MigrationStringBuilder
+  attr_reader :model_configuration
+
+  def initialize(model_configuration)
+    @model_configuration = model_configuration
+  end
+
+  # EG: CreateDriver name:string contact_number:string
+  def to_s
+    "Create#{model_configuration.as_constant} #{extra_columns}"
+  end
+
+private
+
+  # Should be in the format attribute_name:type attribute_name:type
+  # EG: name:string date_of_birth:datetime
+  def model_attributes
+    model_configuration.attributes.collect(&:as_migration_component)
+  end
+
+  def extra_columns
+    default_columns = ["created_at:datetime", "updated_at:datetime"]
+    default_columns << "deleted_at:datetime:index" if model_configuration.soft_delete
+    (model_attributes + default_columns).join(" ")
+  end
+end

--- a/spec/lib/support/migration_string_builder_spec.rb
+++ b/spec/lib/support/migration_string_builder_spec.rb
@@ -12,7 +12,7 @@ describe MigrationStringBuilder do
     it { should eq "CreateTestModel name:string:index created_at:datetime updated_at:datetime" }
 
     describe "option: soft_delete" do
-      before { allow(configuration).to receive(:soft_delete) { soft_delete } }
+      before { allow(configuration).to receive(:soft_delete).and_return(soft_delete) }
 
       context "when soft_delete is false" do
         let(:soft_delete) { false }

--- a/spec/lib/support/migration_string_builder_spec.rb
+++ b/spec/lib/support/migration_string_builder_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe MigrationStringBuilder do
+
+  let(:builder) { MigrationStringBuilder.new(configuration) }
+  let(:configuration)   { ModelConfiguration.new(test_model_path) }
+  let(:test_model_path) { File.join("spec", "support", "test_model.yaml") }
+
+  describe "#to_s" do
+    subject(:output) { builder.to_s }
+
+    it { should eq "CreateTestModel name:string:index created_at:datetime updated_at:datetime" }
+
+    describe "option: soft_delete" do
+      before { allow(configuration).to receive(:soft_delete) { soft_delete } }
+
+      context "when soft_delete is false" do
+        let(:soft_delete) { false }
+        it { should_not include "deleted_at:datetime:index" }
+      end
+
+      context "when soft_delete is true" do
+        let(:soft_delete) { true }
+        it { should include "deleted_at:datetime:index" }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,13 @@ Bundler.require
 require 'rails/all'
 
 Dir.glob("./lib/model_configuration/**/*.rb", &method(:require))
+Dir.glob("./lib/support/**/*.rb", &method(:require))
 
 def build_model_configuration
   test_model_path = File.join("spec", "support", "test_model.yaml")
   ModelConfiguration.new(test_model_path)
+end
+
+RSpec.configure do |config|
+  config.mock_with :rspec
 end

--- a/spec/support/test_model.yaml
+++ b/spec/support/test_model.yaml
@@ -1,2 +1,10 @@
 test_model:
+  namespaces: "admin"
+  soft_delete: false
   skip_ui: true
+  skip_seeds: false
+  attributes:
+    name:
+      type: "string"
+      sortable: true
+      searchable: true


### PR DESCRIPTION
Hey @jordanmaguire not sure how to test this...

Might need your hand...

Feature:

Now we can do:

```ruby
car:
  soft_delete: false
  attributes:
    name:
      type: "string"
      validates:
        presence: true
```

This will not add `acts_as_paranoid` to car model and won't add `deleted_at` columns either.