### PR TITLE
Adding support to text fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ model_name:
   skip_seeds: true
   # Do not create controller, routes, views, or specs for the above. `false` by default.
   skip_ui: true
+  # Adds support to soft delete for this model (acts_as_paranoid). `true` by default
+  soft_delete: true
 ```
 
 ## Attributes
@@ -28,7 +30,7 @@ You can specify which attributes should be on your model thusly:
 
 ```yaml
 model_name:
-  soft_delete: false # true by default
+  soft_delete: false
   skip_ui: false # true by default (only used by scaffold generator)
   attributes:
     attribute_name:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ model_name:
       type: decimal
       type: integer
       type: string
+      type: text
 
       # enum should also provide enum_options
       type: enum

--- a/lib/generators/frontier_crud_views/templates/index.html.haml
+++ b/lib/generators/frontier_crud_views/templates/index.html.haml
@@ -17,14 +17,12 @@
     - <%= model_configuration.ivar_collection %>.each do |<%= model_configuration.model_name %>|
       %tr
 <% model_configuration.attributes.select(&:show_on_index?).each do |attribute| -%>
-<% if attribute.type == 'text' -%>
-        %td= truncate(<%= "#{model_configuration.model_name}.#{attribute.name}" %>, length: 30)
-<% else -%>
-        %td= <%= "#{model_configuration.model_name}.#{attribute.name}" %>
-<% end -%>
+        %td= attribute.as_index_string
 <% end -%>
         %td.actions
-          = link_to("Edit", <%= model_configuration.url_builder.edit_path %>, class: "button") if policy(<%= model_configuration.model_name %>).edit?
-          = link_to("Delete", <%= model_configuration.url_builder.delete_path %>, method: :delete, data: { confirm: "Are you sure you want to delete this <%= model_configuration.as_title %>?" }, class: "button") if policy(<%= model_configuration.model_name %>).destroy?
+          - if policy(<%= model_configuration.model_name %>).edit?
+            = link_to("Edit", <%= model_configuration.url_builder.edit_path %>, class: "button")
+          - if policy(<%= model_configuration.model_name %>).destroy?
+            = link_to("Delete", <%= model_configuration.url_builder.delete_path %>, method: :delete, data: { confirm: "Are you sure you want to delete this <%= model_configuration.as_title %>?" }, class: "button")
 
 = paginate <%= model_configuration.ivar_collection %>

--- a/lib/generators/frontier_crud_views/templates/index.html.haml
+++ b/lib/generators/frontier_crud_views/templates/index.html.haml
@@ -17,10 +17,14 @@
     - <%= model_configuration.ivar_collection %>.each do |<%= model_configuration.model_name %>|
       %tr
 <% model_configuration.attributes.select(&:show_on_index?).each do |attribute| -%>
+<% if attribute.type == 'text' -%>
+        %td= truncate(<%= "#{model_configuration.model_name}.#{attribute.name}" %>, length: 30)
+<% else -%>
         %td= <%= "#{model_configuration.model_name}.#{attribute.name}" %>
 <% end -%>
+<% end -%>
         %td.actions
-          = link_to "Edit", <%= model_configuration.url_builder.edit_path %>, class: "button"
-          = link_to "Delete", <%= model_configuration.url_builder.delete_path %>, method: :delete, data: { confirm: "Are you sure you want to delete this <%= model_configuration.as_title %>?" }, class: "button"
+          = link_to("Edit", <%= model_configuration.url_builder.edit_path %>, class: "button") if policy(<%= model_configuration.model_name %>).edit?
+          = link_to("Delete", <%= model_configuration.url_builder.delete_path %>, method: :delete, data: { confirm: "Are you sure you want to delete this <%= model_configuration.as_title %>?" }, class: "button") if policy(<%= model_configuration.model_name %>).destroy?
 
 = paginate <%= model_configuration.ivar_collection %>

--- a/lib/model_configuration/attribute.rb
+++ b/lib/model_configuration/attribute.rb
@@ -60,6 +60,14 @@ class ModelConfiguration
       properties[:show_on_index].nil? ? true : properties[:show_on_index]
     end
 
+    # index refers to the index.html.haml template, nothing to do with DB.
+    def as_index_string
+      case type
+        when "text" then "truncate(#{model_configuration.model_name}.#{name}, length: 30)"
+        else "#{model_configuration.model_name}.#{name}"
+      end
+    end
+
   # Models
 
     def is_association?

--- a/lib/model_configuration/attribute/factory_declaration.rb
+++ b/lib/model_configuration/attribute/factory_declaration.rb
@@ -32,6 +32,8 @@ private
       enum_data
     when "string"
       string_data
+    when "text"
+      text_data
     else
       raise(ArgumentError, "Unsupported Type: #{attribute.type}")
     end
@@ -53,6 +55,10 @@ private
 
   def number_data
     "rand(9999)"
+  end
+
+  def text_data
+    "Faker::Lorem.paragraph(5)"
   end
 
   def string_data

--- a/lib/model_configuration/model_configuration.rb
+++ b/lib/model_configuration/model_configuration.rb
@@ -8,7 +8,7 @@ class ModelConfiguration
 
   # Example YAML:
   #   driver:
-  #     namespaces: "admin"
+  #     namespaces: ["admin"]
   #     soft_delete: false
   #     skip_ui: false
   #     skip_seeds: false

--- a/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
+++ b/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
@@ -108,6 +108,11 @@ describe ModelConfiguration::Attribute::FactoryDeclaration do
       end
     end
 
+    context "type is 'text'" do
+      let(:type) { "text" }
+      it { should eq("field_name { Faker::Lorem.paragraph(5) }") }
+    end
+
     context "type is something else" do
       let(:type) { "heroin" }
       specify { expect { subject }.to raise_error(ArgumentError) }

--- a/spec/lib/model_configuration/attribute_spec.rb
+++ b/spec/lib/model_configuration/attribute_spec.rb
@@ -90,6 +90,20 @@ describe ModelConfiguration::Attribute do
     end
   end
 
+  describe "#as_index_string" do
+    subject { attribute.as_index_string }
+
+    context "when attribute type is text" do
+      before { allow(attribute).to receive(:type) { "text" } }
+
+      it { should eq "truncate(test_model.attribute_name, length: 30)" }
+    end
+
+    context "when attribute type is not text" do
+      it { should eq "test_model.attribute_name" }
+    end
+  end
+
   describe "#validations" do
     subject { attribute.validations }
     let(:options) { {validates: validates} }


### PR DESCRIPTION
Now you can do:

```yaml
event_update:
  attributes:
    content:
      type: "text"
      validates:
        presence: true
    video_url:
      type: "string"
```

This will automatically truncate text attributes:

```haml
%table
  %thead
    %tr
      %th Content
      %th Video Url
      %th.actions Actions
  %tbody
    - @event_updates.each do |event_update|
      %tr
        %td= truncate(event_update.content, length: 30)
        %td= event_update.video_url
```

... and generate factories properly:

```ruby
FactoryGirl.define do
  factory :event_update do
    content {  FFaker::Lorem.paragraph(5) }
  end
end
```

Bonus:

Added policy checks on index actions:

```haml
%td.actions
  = link_to("Edit", edit_event_update_path(event_update), class: "button") if policy(event_update).edit?
  = link_to("Delete", event_update_path(event_update), method: :delete, data: { confirm: "Are you sure you want to delete this Event Update?" }, class: "button") if policy(event_update).destroy?
```