### PR TITLE
Feature/association form

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ model_name:
   skip_ui: false # true by default (only used by scaffold generator)
   attributes:
     attribute_name:
+      # Set primary to true if you want this attribute to be used for #to_s and for
+      # checks in the feature specs. Chooses first attribute by default.
+      primary: true
       # Set to false if you don't want this attribute to be represented on the index
       # Note: This is true by default
       show_on_index: false

--- a/lib/frontier.rb
+++ b/lib/frontier.rb
@@ -1,0 +1,2 @@
+class Frontier
+end

--- a/lib/generators/frontier_crud_views/templates/_form.html.haml
+++ b/lib/generators/frontier_crud_views/templates/_form.html.haml
@@ -3,7 +3,7 @@
 <% model_configuration.attributes.each_with_index do |attribute, index| -%>
 <% options = {} -%>
 <% options = {autofocus: true} if index.zero? -%>
-  = <%= attribute.as_input(options) %>
+  = <%= Frontier::Input::Factory.build_for(attribute).to_s(options) %>
 <% end -%>
   .form-actions
     = f.button :submit

--- a/lib/model_configuration/association.rb
+++ b/lib/model_configuration/association.rb
@@ -5,6 +5,14 @@ class ModelConfiguration
 
     ID_REGEXP = /_id\z/
 
+    def association_class
+      if properties[:class_name].present?
+        properties[:class_name]
+      else
+        name.sub(ID_REGEXP, "").camelize
+      end
+    end
+
     def as_factory_name
       ":#{association_class.underscore}"
     end
@@ -33,23 +41,6 @@ class ModelConfiguration
 
     def as_factory_declaration
       ModelConfiguration::Association::FactoryDeclaration.new(self).to_s
-    end
-
-    # Views
-
-    def as_input(options={})
-      options = options.merge({collection: "#{association_class}.all"})
-      super
-    end
-
-  private
-
-    def association_class
-      if properties[:class_name].present?
-        properties[:class_name]
-      else
-        name.sub(ID_REGEXP, "").camelize
-      end
     end
 
   end

--- a/lib/model_configuration/attribute.rb
+++ b/lib/model_configuration/attribute.rb
@@ -1,12 +1,13 @@
 class ModelConfiguration
   class Attribute
 
-    attr_reader :model_configuration, :name, :properties
+    attr_reader :model_configuration, :is_primary, :name, :properties
 
     def initialize(model_configuration, name, properties)
       @model_configuration = model_configuration
       @name = name.to_s
       @properties = properties
+      @is_primary = @properties[:primary] == true
     end
 
     # some_thing -> "Some thing"
@@ -25,6 +26,10 @@ class ModelConfiguration
 
     def as_symbol
       ":#{name}"
+    end
+
+    def is_primary?
+      !!@is_primary
     end
 
     def sortable?

--- a/lib/model_configuration/attribute.rb
+++ b/lib/model_configuration/attribute.rb
@@ -53,10 +53,6 @@ class ModelConfiguration
       end
     end
 
-    def as_input(options={})
-      ModelConfiguration::Attribute::InputImplementation.new(self).to_s(options)
-    end
-
     def is_enum?
       properties[:type] == "enum"
     end
@@ -111,6 +107,5 @@ end
 
 require_relative "attribute/constant.rb"
 require_relative "attribute/factory_declaration.rb"
-require_relative "attribute/input_implementation.rb"
 require_relative "attribute/migration_component.rb"
 require_relative "attribute/validation/factory.rb"

--- a/lib/model_configuration/model_configuration.rb
+++ b/lib/model_configuration/model_configuration.rb
@@ -44,8 +44,11 @@ class ModelConfiguration
     "@#{model_name}"
   end
 
+  # The primary attribute is used for:
+  #   * Model#to_s (and spec)
+  #   * Determining whether or not an instance of the model is visible in feature specs
   def primary_attribute
-    attributes.first
+    attributes.find(&:is_primary?) || attributes.first
   end
 
   def skip_ui?

--- a/lib/support/input.rb
+++ b/lib/support/input.rb
@@ -1,4 +1,46 @@
 require_relative '../frontier.rb'
 
 class Frontier::Input
+
+  attr_reader :attribute
+
+  def initialize(attribute)
+    @attribute = attribute
+  end
+
+protected
+
+  def attribute_options
+    options = {}
+
+    # datetimes and dates should use the date_picker input type
+    #
+    # f.input :attribute_name, as: :date_picker
+    if attribute.type.in?(["datetime", "date"])
+      options[:as] = ":date_picker"
+    end
+
+    # For inclusion validations, we should ensure that the required values are passed as a
+    # collection to the input. EG:
+    #
+    # attribute_name:
+    #   validates:
+    #     inclusion: [1, 2, 3]
+    #
+    # f.input :attribute_name, collection: [1, 2, 3]
+    #
+    if inclusion_validation = attribute.validations.find {|val| val.key.to_s == "inclusion" }
+      options[:collection] = inclusion_validation.corresponding_constant.name
+    end
+
+    options
+  end
+
+  def input_options(additional_options)
+    # Take options like {one: ':two', abacus: 666} and create collection of strings
+    # ["abacus: 666", "one: :two"]
+    additional_options_as_strings = attribute_options.merge(additional_options).map {|key, value| "#{key}: #{value}"}.sort
+    additional_options_as_strings
+  end
+
 end

--- a/lib/support/input.rb
+++ b/lib/support/input.rb
@@ -1,0 +1,4 @@
+require_relative '../frontier.rb'
+
+class Frontier::Input
+end

--- a/lib/support/input/association.rb
+++ b/lib/support/input/association.rb
@@ -1,10 +1,14 @@
 require_relative 'attribute.rb'
 
-class Frontier::Input::Association < Frontier::Input::Attribute
+class Frontier::Input::Association < Frontier::Input
 
   def to_s(options={})
     options = options.merge({collection: "#{association.association_class}.all"})
-    super
+    # Should convert attribute "state" into:
+    #   f.association :state_id, collection: State.all
+    # With additional options as above you'd get:
+    #   f.association :state_id, abacus: 666, collection: State.all, one: :two
+    ["f.association #{attribute.as_field_name}", *input_options(options)].join(", ")
   end
 
   alias association attribute

--- a/lib/support/input/association.rb
+++ b/lib/support/input/association.rb
@@ -1,0 +1,12 @@
+require_relative 'attribute.rb'
+
+class Frontier::Input::Association < Frontier::Input::Attribute
+
+  def to_s(options={})
+    options = options.merge({collection: "#{association.association_class}.all"})
+    super
+  end
+
+  alias association attribute
+
+end

--- a/lib/support/input/attribute.rb
+++ b/lib/support/input/attribute.rb
@@ -1,6 +1,6 @@
-require_relative '../attribute'
+require_relative '../input.rb'
 
-class ModelConfiguration::Attribute::InputImplementation
+class Frontier::Input::Attribute
 
   attr_reader :attribute
 

--- a/lib/support/input/attribute.rb
+++ b/lib/support/input/attribute.rb
@@ -1,54 +1,9 @@
 require_relative '../input.rb'
 
-class Frontier::Input::Attribute
-
-  attr_reader :attribute
-
-  def initialize(attribute)
-    @attribute = attribute
-  end
+class Frontier::Input::Attribute < Frontier::Input
 
   def to_s(options={})
-    # Should convert attribute "state" into:
-    #   f.input :state_id, collection: State.all
-    # With additional options as above you'd get:
-    #   f.input :state_id, abacus: 666, collection: State.all, one: :two
-    input_declaration = ["f.input #{attribute.as_field_name}", *input_options(options)].join(", ")
-  end
-
-private
-
-  def attribute_options
-    options = {}
-
-    # datetimes and dates should use the date_picker input type
-    #
-    # f.input :attribute_name, as: :date_picker
-    if attribute.type.in?(["datetime", "date"])
-      options[:as] = ":date_picker"
-    end
-
-    # For inclusion validations, we should ensure that the required values are passed as a
-    # collection to the input. EG:
-    #
-    # attribute_name:
-    #   validates:
-    #     inclusion: [1, 2, 3]
-    #
-    # f.input :attribute_name, collection: [1, 2, 3]
-    #
-    if inclusion_validation = attribute.validations.find {|val| val.key.to_s == "inclusion" }
-      options[:collection] = inclusion_validation.corresponding_constant.name
-    end
-
-    options
-  end
-
-  def input_options(additional_options)
-    # Take options like {one: ':two', abacus: 666} and create collection of strings
-    # ["abacus: 666", "one: :two"]
-    additional_options_as_strings = attribute_options.merge(additional_options).map {|key, value| "#{key}: #{value}"}.sort
-    additional_options_as_strings
+    ["f.input #{attribute.as_field_name}", *input_options(options)].join(", ")
   end
 
 end

--- a/lib/support/input/factory.rb
+++ b/lib/support/input/factory.rb
@@ -1,0 +1,18 @@
+require_relative '../input.rb'
+require_relative 'association.rb'
+require_relative 'attribute.rb'
+
+class Frontier::Input::Factory
+
+  def self.build_for(attribute_or_association)
+    case attribute_or_association
+    when ModelConfiguration::Association
+      Frontier::Input::Association.new(attribute_or_association)
+    when ModelConfiguration::Attribute
+      Frontier::Input::Attribute.new(attribute_or_association)
+    else
+      raise(ArgumentError, "Unhandled instance passed through: #{attribute_or_association}")
+    end
+  end
+
+end

--- a/spec/lib/model_configuration/association_spec.rb
+++ b/spec/lib/model_configuration/association_spec.rb
@@ -45,42 +45,6 @@ describe ModelConfiguration::Association do
     end
   end
 
-  describe "#as_input" do
-    subject { association.as_input(input_options) }
-    let(:input_options) { {} }
-
-    describe "providing additional options" do
-      let(:expected_output) { "f.input :model_id, collection: Model.all, my_option: :jordan_rules" }
-      let(:name) { "model_id" }
-      let(:input_options) { {my_option: ":jordan_rules"} }
-
-      it { should eq(expected_output) }
-    end
-
-    describe "setting name of input" do
-      context "with class_name declared" do
-        let(:expected_output) { "f.input :association_name_id, collection: Dong.all" }
-        let(:options) { {class_name: "Dong"} }
-
-        it { should eq(expected_output) }
-      end
-
-      context "without class_name declared" do
-        let(:expected_output) { "f.input :model_id, collection: Model.all" }
-
-        context "when field_name includes _id already" do
-          let(:name) { "model_id" }
-          it { should eq(expected_output) }
-        end
-
-        context "when field_name doesn't include _id" do
-          let(:name) { "model" }
-          it { should eq(expected_output) }
-        end
-      end
-    end
-  end
-
   describe "#is_association?" do
     subject { association.is_association? }
     it { should eq(true) }

--- a/spec/lib/model_configuration/attribute_spec.rb
+++ b/spec/lib/model_configuration/attribute_spec.rb
@@ -78,18 +78,6 @@ describe ModelConfiguration::Attribute do
     end
   end
 
-  describe "#as_input" do
-    subject { attribute.as_input(options) }
-    let(:options) { {} }
-
-    describe "providing additional options" do
-      let(:expected_output) { "f.input :attribute_name, my_option: :jordan_rules" }
-      let(:options) { {my_option: ":jordan_rules"} }
-
-      it { should eq(expected_output) }
-    end
-  end
-
   describe "#show_on_index?" do
     subject { attribute.show_on_index? }
 

--- a/spec/lib/model_configuration/attribute_spec.rb
+++ b/spec/lib/model_configuration/attribute_spec.rb
@@ -58,6 +58,26 @@ describe ModelConfiguration::Attribute do
     end
   end
 
+  describe "#is_primary?" do
+    subject { attribute.is_primary? }
+    let(:options) { {primary: primary} }
+
+    context "when primary is true" do
+      let(:primary) { true }
+      it { should eq(true) }
+    end
+
+    context "when primary is false" do
+      let(:primary) { false }
+      it { should eq(false) }
+    end
+
+    context "when primary is nil" do
+      let(:primary) { nil }
+      it { should eq(false) }
+    end
+  end
+
   describe "#as_input" do
     subject { attribute.as_input(options) }
     let(:options) { {} }

--- a/spec/lib/model_configuration/model_configuration_spec.rb
+++ b/spec/lib/model_configuration/model_configuration_spec.rb
@@ -34,6 +34,44 @@ describe ModelConfiguration do
     it { should eq("@test_model") }
   end
 
+  describe "#primary_attribute" do
+    subject(:primary_attribute) { model_configuration.primary_attribute }
+
+    let(:model_configuration) { ModelConfiguration.new(model_options) }
+    let(:model_options) do
+      {
+        test_model: {
+          attributes: attributes
+        }
+      }
+    end
+
+    context "when there is a primary attribute" do
+      let(:attributes) do
+          {
+            primary_attribute: {primary: true},
+            other_attribute: {}
+          }
+      end
+      it "returns the primary attribute" do
+        expect(primary_attribute.name).to eq("primary_attribute")
+      end
+    end
+
+    context "when there is no primary attribute" do
+      let(:attributes) do
+        {
+          primary_attribute: {},
+          other_attribute: {}
+        }
+      end
+
+      it "returns the first attribute" do
+        expect(primary_attribute.name).to eq("primary_attribute")
+      end
+    end
+  end
+
   describe "hiding/showing UI elements" do
     let(:model_configuration) { ModelConfiguration.new(model_options) }
     let(:model_options) { {test_model: {skip_ui: skip_ui}} }

--- a/spec/support/input/association_spec.rb
+++ b/spec/support/input/association_spec.rb
@@ -12,7 +12,7 @@ describe Frontier::Input::Association do
     let(:input_options) { {} }
 
     describe "providing additional options" do
-      let(:expected_output) { "f.input :association_name_id, collection: AssociationName.all, my_option: :jordan_rules" }
+      let(:expected_output) { "f.association :association_name_id, collection: AssociationName.all, my_option: :jordan_rules" }
       let(:name) { "association_name_id" }
       let(:input_options) { {my_option: ":jordan_rules"} }
 
@@ -21,14 +21,14 @@ describe Frontier::Input::Association do
 
     describe "setting name of input" do
       context "with class_name declared" do
-        let(:expected_output) { "f.input :association_name_id, collection: Dong.all" }
+        let(:expected_output) { "f.association :association_name_id, collection: Dong.all" }
         let(:options) { {class_name: "Dong"} }
 
         it { should eq(expected_output) }
       end
 
       context "without class_name declared" do
-        let(:expected_output) { "f.input :association_name_id, collection: AssociationName.all" }
+        let(:expected_output) { "f.association :association_name_id, collection: AssociationName.all" }
 
         context "when field_name includes _id already" do
           let(:name) { "association_name_id" }

--- a/spec/support/input/association_spec.rb
+++ b/spec/support/input/association_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Frontier::Input::Association do
+
+  let(:input_implementation) { Frontier::Input::Association.new(association) }
+  let(:association) { ModelConfiguration::Association.new(build_model_configuration, name, options) }
+  let(:name) { "association_name_id" }
+  let(:options) { {} }
+
+  describe "#to_s" do
+    subject { input_implementation.to_s(input_options) }
+    let(:input_options) { {} }
+
+    describe "providing additional options" do
+      let(:expected_output) { "f.input :association_name_id, collection: AssociationName.all, my_option: :jordan_rules" }
+      let(:name) { "association_name_id" }
+      let(:input_options) { {my_option: ":jordan_rules"} }
+
+      it { should eq(expected_output) }
+    end
+
+    describe "setting name of input" do
+      context "with class_name declared" do
+        let(:expected_output) { "f.input :association_name_id, collection: Dong.all" }
+        let(:options) { {class_name: "Dong"} }
+
+        it { should eq(expected_output) }
+      end
+
+      context "without class_name declared" do
+        let(:expected_output) { "f.input :association_name_id, collection: AssociationName.all" }
+
+        context "when field_name includes _id already" do
+          let(:name) { "association_name_id" }
+          it { should eq(expected_output) }
+        end
+
+        context "when field_name doesn't include _id" do
+          let(:name) { "association_name" }
+          it { should eq(expected_output) }
+        end
+      end
+    end
+  end
+
+end

--- a/spec/support/input/attribute_spec.rb
+++ b/spec/support/input/attribute_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe ModelConfiguration::Attribute::InputImplementation do
+describe Frontier::Input::Attribute do
 
-  let(:input_implementation) { ModelConfiguration::Attribute::InputImplementation.new(attribute) }
+  let(:input_implementation) { Frontier::Input::Attribute.new(attribute) }
   let(:attribute) { ModelConfiguration::Attribute.new(build_model_configuration, name, options) }
   let(:name) { "attribute_name" }
   let(:options) { {} }

--- a/spec/support/input/factory_spec.rb
+++ b/spec/support/input/factory_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Frontier::Input::Factory do
+
+  describe ".build_for" do
+    subject { Frontier::Input::Factory.build_for(instance) }
+
+    context "when instance is a ModelConfiguration::Association" do
+      let(:instance) { ModelConfiguration::Association.new(nil, nil, {}) }
+      it "returns a Frontier::Input::Association" do
+        expect(subject).to be_kind_of(Frontier::Input::Association)
+      end
+    end
+
+    context "when instance is a ModelConfiguration::Attribute" do
+      let(:instance) { ModelConfiguration::Attribute.new(nil, nil, {}) }
+      it "returns a Frontier::Input::Attribute" do
+        expect(subject).to be_kind_of(Frontier::Input::Attribute)
+      end
+    end
+
+    context "when instance is something else" do
+      let(:instance) { "YOLO!" }
+      it "raises an ArgumentError" do
+        expect { subject }.to raise_exception(ArgumentError)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
Stacked on https://github.com/thefrontiergroup/frontier_generators/pull/55

Did a bunch of refactoring so that instead of calling the #as_input from the bloated attribute/association models I can now just factory an input object up and call #to_s on it.

Now associations will be presented properly as an input (Hell yusssss)