### PR TITLE
Fix enum_options to be a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ model_name:
 
       # enum should also provide enum_options
       type: enum
-      enum_options: [:admin, :public]
+      enum_options: ['admin', 'public']
 ```
 
 ## Associations

--- a/lib/model_configuration/attribute.rb
+++ b/lib/model_configuration/attribute.rb
@@ -46,8 +46,8 @@ class ModelConfiguration
       # Should look like:
       #   enum attribute_name: ["one", "two"]
       if is_enum?
-        enum_options_as_string = properties[:enum_options].collect {|x| "\"#{x}\""}.join(", ")
-        "enum #{name}: [#{enum_options_as_string}]"
+        enum_options_as_hash = properties[:enum_options].each_with_index.collect {|key, index| "#{key}: #{index}"}.join(", ")
+        "enum #{name}: {#{enum_options_as_hash}}"
       else
         raise(ArgumentError, "Attempting to display field #{name} as enum, but is #{type}")
       end

--- a/spec/lib/model_configuration/attribute_spec.rb
+++ b/spec/lib/model_configuration/attribute_spec.rb
@@ -15,8 +15,8 @@ describe ModelConfiguration::Attribute do
     end
 
     context "when field is an enum" do
-      let(:options) { {type: "enum", enum_options: ["one", "two"]} }
-      it { should eq("enum attribute_name: [\"one\", \"two\"]") }
+      let(:options) { {type: "enum", enum_options: ["zero", "one"]} }
+      it { should eq("enum attribute_name: {zero: 0, one: 1}") }
     end
   end
 


### PR DESCRIPTION
Fix a bug where enum was using strings instead of symbols.

Also explicitly set enum values (I feel this is clearer but its just my preference).