### PR TITLE
Bug/fix enum options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ model_name:
 
       # enum should also provide enum_options
       type: enum
-      enum_options: [:admin, :public]
+      enum_options: ['admin', 'public']
 ```
 
 ## Associations

--- a/lib/generators/frontier_model/templates/model_spec.rb
+++ b/lib/generators/frontier_model/templates/model_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe <%= model_configuration.as_constant %> do
-
 <% model_configuration.attributes.select(&:validation_required?).each do |attribute| -%>
+
   describe "@<%= attribute.name %>" do
 <% attribute.validations.each do |validation| -%>
 <% case validation.key -%>

--- a/lib/model_configuration/attribute.rb
+++ b/lib/model_configuration/attribute.rb
@@ -45,9 +45,14 @@ class ModelConfiguration
     def as_enum
       # Should look like:
       #   enum attribute_name: ["one", "two"]
+
       if is_enum?
-        enum_options_as_hash = properties[:enum_options].each_with_index.collect {|key, index| "#{key}: #{index}"}.join(", ")
-        "enum #{name}: {#{enum_options_as_hash}}"
+        if (enum_options = properties[:enum_options]).present?
+          enum_options_as_hash = enum_options.each_with_index.collect {|key, index| "#{key}: #{index}"}.join(", ")
+          "enum #{name}: {#{enum_options_as_hash}}"
+        else
+          raise(ArgumentError, "No enum_options provided for attribute: #{name}")
+        end
       else
         raise(ArgumentError, "Attempting to display field #{name} as enum, but is #{type}")
       end

--- a/lib/model_configuration/attribute.rb
+++ b/lib/model_configuration/attribute.rb
@@ -46,8 +46,8 @@ class ModelConfiguration
       # Should look like:
       #   enum attribute_name: ["one", "two"]
       if is_enum?
-        enum_options_as_string = properties[:enum_options].collect {|x| "\"#{x}\""}.join(", ")
-        "enum #{name}: [#{enum_options_as_string}]"
+        enum_options_as_hash = properties[:enum_options].each_with_index.collect {|key, index| "#{key}: #{index}"}.join(", ")
+        "enum #{name}: {#{enum_options_as_hash}}"
       else
         raise(ArgumentError, "Attempting to display field #{name} as enum, but is #{type}")
       end

--- a/lib/model_configuration/attribute.rb
+++ b/lib/model_configuration/attribute.rb
@@ -48,7 +48,7 @@ class ModelConfiguration
 
       if is_enum?
         if (enum_options = properties[:enum_options]).present?
-          enum_options_as_hash = enum_options.each_with_index.collect {|key, index| "#{key}: #{index}"}.join(", ")
+          enum_options_as_hash = Frontier::HashDecorator.new array_as_hash(enum_options)
           "enum #{name}: {#{enum_options_as_hash}}"
         else
           raise(ArgumentError, "No enum_options provided for attribute: #{name}")
@@ -107,6 +107,11 @@ class ModelConfiguration
       ModelConfiguration::Attribute::MigrationComponent.new(self).to_s
     end
 
+  private
+
+    def array_as_hash(array)
+      array.zip(0..array.length).to_h
+    end
   end
 end
 

--- a/lib/model_configuration/attribute/factory_declaration.rb
+++ b/lib/model_configuration/attribute/factory_declaration.rb
@@ -54,7 +54,7 @@ private
   end
 
   def text_data
-    "Faker::Lorem.paragraph(5)"
+    "FFaker::Lorem.paragraph(5)"
   end
 
   def string_data

--- a/lib/model_configuration/attribute/factory_declaration.rb
+++ b/lib/model_configuration/attribute/factory_declaration.rb
@@ -46,7 +46,7 @@ private
   end
 
   def enum_data
-    "#{attribute.model_configuration.as_constant}.#{attribute.name.pluralize}.keys"
+    "#{attribute.model_configuration.as_constant}.#{attribute.name.pluralize}.keys.sample"
   end
 
   def number_data

--- a/lib/model_configuration/attribute/factory_declaration.rb
+++ b/lib/model_configuration/attribute/factory_declaration.rb
@@ -46,11 +46,7 @@ private
   end
 
   def enum_data
-    if attribute.properties[:enum_options].present?
-      "#{attribute.properties[:enum_options]}.sample"
-    else
-      raise(ArgumentError, "No enum_options provided for attribute: #{attribute.name}")
-    end
+    "#{attribute.model_configuration.as_constant}.#{attribute.name.pluralize}.keys"
   end
 
   def number_data

--- a/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
+++ b/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
@@ -102,7 +102,7 @@ describe ModelConfiguration::Attribute::FactoryDeclaration do
 
     context "type is 'text'" do
       let(:type) { "text" }
-      it { should eq("field_name { Faker::Lorem.paragraph(5) }") }
+      it { should eq("field_name { FFaker::Lorem.paragraph(5) }") }
     end
 
     context "type is something else" do

--- a/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
+++ b/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
@@ -38,7 +38,7 @@ describe ModelConfiguration::Attribute::FactoryDeclaration do
       let(:options) { {type: type} }
       let(:type)    { "enum" }
 
-      it { should eq("field_name { TestModel.field_names.keys }") }
+      it { should eq("field_name { TestModel.field_names.keys.sample }") }
     end
 
     context "type is 'integer'" do

--- a/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
+++ b/spec/lib/model_configuration/attribute/factory_declaration_spec.rb
@@ -35,18 +35,10 @@ describe ModelConfiguration::Attribute::FactoryDeclaration do
     end
 
     context "type is 'enum'" do
-      let(:options) { {enum_options: enum_options, type: type} }
+      let(:options) { {type: type} }
       let(:type)    { "enum" }
 
-      context "when enum_options is set" do
-        let(:enum_options) { ["one", "two"] }
-        it { should eq("field_name { [\"one\", \"two\"].sample }") }
-      end
-
-      context "when enum_options is not set" do
-        let(:enum_options) { nil }
-        specify { expect { subject }.to raise_error(ArgumentError) }
-      end
+      it { should eq("field_name { TestModel.field_names.keys }") }
     end
 
     context "type is 'integer'" do

--- a/spec/lib/model_configuration/attribute_spec.rb
+++ b/spec/lib/model_configuration/attribute_spec.rb
@@ -15,8 +15,19 @@ describe ModelConfiguration::Attribute do
     end
 
     context "when field is an enum" do
-      let(:options) { {type: "enum", enum_options: ["zero", "one"]} }
-      it { should eq("enum attribute_name: {zero: 0, one: 1}") }
+      before { options[:type] = "enum" }
+
+      context "enum_options is present" do
+        before { options[:enum_options] = ["zero", "one"] }
+
+        it { should eq("enum attribute_name: {zero: 0, one: 1}") }
+      end
+
+      context "enum_options is blank" do
+        before { options[:enum_options] = double(present?: false) }
+
+        specify { expect { subject }.to raise_error(ArgumentError) }
+      end
     end
   end
 

--- a/spec/lib/model_configuration/attribute_spec.rb
+++ b/spec/lib/model_configuration/attribute_spec.rb
@@ -15,8 +15,8 @@ describe ModelConfiguration::Attribute do
     end
 
     context "when field is an enum" do
-      let(:options) { {type: "enum", enum_options: ["one", "two"]} }
-      it { should eq("enum attribute_name: [\"one\", \"two\"]") }
+      let(:options) { {type: "enum", enum_options: ["zero", "one"]} }
+      it { should eq("enum attribute_name: {zero: 0, one: 1}") }
     end
   end
 


### PR DESCRIPTION
Fix a bug where enum was using strings instead of symbols.

Also explicitly set enum values (I feel this is clearer but its just my preference).