### PR TITLE
Fix #98: Pass correct values through

### DIFF
--- a/lib/frontier/authorization/check.rb
+++ b/lib/frontier/authorization/check.rb
@@ -1,29 +1,20 @@
 class Frontier::Authorization::Check
 
-  attr_reader :action, :model_configuration
+  attr_reader :action, :authorizable_object, :model_configuration
 
-  def initialize(model_configuration, action)
-    @model_configuration = model_configuration
+  def initialize(model_configuration, authorizable_object, action)
     @action = action
+    @authorizable_object = authorizable_object
+    @model_configuration = model_configuration
   end
 
   def to_s
     if model_configuration.using_pundit?
-      if action.to_sym == :new
-        # policy(User).new?
-        "policy(#{model_configuration.as_constant}).#{action}?"
-      else
-        # policy(@user).edit?
-        "policy(#{model_configuration.as_ivar_instance}).#{action}?"
-      end
+      # policy(User).new?
+      "policy(#{authorizable_object}).#{action}?"
     else
-      if action.to_sym == :new
-        # can?(:new, User)
-        "can?(:#{action}, #{model_configuration.as_constant})"
-      else
-        # can?(:edit, @user)
-        "can?(:#{action}, #{model_configuration.as_ivar_instance})"
-      end
+      # can?(:new, User)
+      "can?(:#{action}, #{authorizable_object})"
     end
   end
 

--- a/lib/generators/frontier_crud_views/templates/index.html.haml
+++ b/lib/generators/frontier_crud_views/templates/index.html.haml
@@ -1,7 +1,7 @@
 %h1 <%= model_configuration.as_title %> Management
 
 <% if model_configuration.show_create? -%>
-- if <%= Frontier::Authorization::Check.new(model_configuration, :new) %>
+- if <%= Frontier::Authorization::Check.new(model_configuration, model_configuration.as_constant, :new) %>
   %p= link_to "Add new <%= model_configuration.as_title %>", <%= model_configuration.url_builder.new_path %>, class: "btn"
 <% end -%>
 
@@ -25,11 +25,11 @@
 <% end -%>
           %td.actions
 <% if model_configuration.show_update? -%>
-            - if <%= Frontier::Authorization::Check.new(model_configuration, :edit) %>
+            - if <%= Frontier::Authorization::Check.new(model_configuration, model_configuration.model_name, :edit) %>
               = link_to("Edit", <%= model_configuration.url_builder.edit_path %>, class: "btn btn-small")
 <% end -%>
 <% if model_configuration.show_delete? -%>
-            - if <%= Frontier::Authorization::Check.new(model_configuration, :destroy) %>
+            - if <%= Frontier::Authorization::Check.new(model_configuration, model_configuration.model_name, :destroy) %>
               = link_to("Delete", <%= model_configuration.url_builder.delete_path %>, method: :delete, data: { confirm: "Are you sure you want to delete this <%= model_configuration.as_title %>?" }, class: "btn btn-small btn-danger")
 <% end -%>
     - else

--- a/spec/lib/frontier/authorization/check_spec.rb
+++ b/spec/lib/frontier/authorization/check_spec.rb
@@ -4,36 +4,24 @@ describe Frontier::Authorization::Check do
 
   describe "#to_s" do
     subject { authorize_check.to_s }
-    let(:authorize_check) { Frontier::Authorization::Check.new(model_configuration, action) }
+    let(:authorize_check)     { Frontier::Authorization::Check.new(model_configuration, object, action) }
     let(:model_configuration) { Frontier::ModelConfiguration.new(attributes) }
-    let(:attributes) { {test_model: {authorization: authorization}}.stringify_keys }
+    let(:attributes)          { {test_model: {authorization: authorization}}.stringify_keys }
 
     context "when using Pundit" do
       let(:authorization) { "pundit" }
+      let(:object) { "TestModel" }
+      let(:action) { :new }
 
-      context "and the action is new" do
-        let(:action) { :new }
-        it { should eq("policy(TestModel).new?") }
-      end
-
-      context "and the action is not new" do
-        let(:action) { :edit }
-        it { should eq("policy(@test_model).edit?") }
-      end
+      it { should eq("policy(TestModel).new?") }
     end
 
     context "when using CanCanCan" do
       let(:authorization) { "cancancan" }
+      let(:object) { "TestModel" }
+      let(:action) { :new }
 
-      context "and the action is new" do
-        let(:action) { :new }
-        it { should eq("can?(:new, TestModel)") }
-      end
-
-      context "and the action is not new" do
-        let(:action) { :edit }
-        it { should eq("can?(:edit, @test_model)") }
-      end
+      it { should eq("can?(:new, TestModel)") }
     end
   end
 


### PR DESCRIPTION
Was rendering ivars. Now you pass the object you want to authorize into the method, allowing us to correctly pass through a local variable in the view.