### PR TITLE
Fix #111: Use build strategy

### DIFF
--- a/lib/frontier/association/factory_declaration.rb
+++ b/lib/frontier/association/factory_declaration.rb
@@ -6,14 +6,31 @@ class Frontier::Association::FactoryDeclaration
     @association = association
   end
 
+  ##
+  # We use the :build strategy by default. Otherwise FG will persist the association
+  # even when we FactoryGirl.build the parent object.
+  #
+  # This is almost always problematic. Why persist children if we don't necessarily
+  # want to persist the parent? EG: In a spec where we are trying to avoid
+  # hitting the DB for performance reasons.
+  #
+  # If we build the associations, they will be persisted when we save the parent
+  # object anyway.
+  #
   def to_s
     if (class_name = association.properties[:class_name]).present?
-      # association :delivery_address, factory: :address
-      "association #{association.as_symbol}, factory: :#{class_name.underscore}"
+      # association :delivery_address, strategy: :build, factory: :address
+      "#{base_association_declaration}, strategy: :build, factory: :#{class_name.underscore}"
     else
-      # association :address
-      "association #{association.as_symbol}"
+      # association :address, strategy: :build
+      "#{base_association_declaration}, strategy: :build"
     end
+  end
+
+private
+
+  def base_association_declaration
+    "association #{association.as_symbol}"
   end
 
 end

--- a/spec/lib/frontier/association/factory_declaration_spec.rb
+++ b/spec/lib/frontier/association/factory_declaration_spec.rb
@@ -10,12 +10,12 @@ describe Frontier::Association::FactoryDeclaration do
 
     context "class_name is set" do
       let(:class_name) { "ClassName" }
-      it { should eq("association :association_name, factory: :class_name") }
+      it { should eq("association :association_name, strategy: :build, factory: :class_name") }
     end
 
     context "class_name is not set" do
       let(:class_name) { nil }
-      it { should eq("association :association_name") }
+      it { should eq("association :association_name, strategy: :build") }
     end
   end
 


### PR DESCRIPTION
FG associations behave pretty unexpectedly by default.

Using the build strategy makes them behave more as I'd expect.

See my comments in the diff for an explanation.