### PR TITLE
Fix #107: Provide show_on_form attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ model_name:
       # Set to false if you don't want this attribute to be represented on the index
       # Note: This is true by default
       show_on_index: false
+      # Set to false to prevent this attribute being used in the form
+      # Note: this is true by default
+      show_on_form: false
 
       # Choose one of the following
       type: boolean

--- a/lib/frontier/attribute.rb
+++ b/lib/frontier/attribute.rb
@@ -62,8 +62,12 @@ class Frontier::Attribute
     properties[:type] == "enum"
   end
 
+  def show_on_form?
+    properties[:show_on_form].nil? || properties[:show_on_form]
+  end
+
   def show_on_index?
-    properties[:show_on_index].nil? ? true : properties[:show_on_index]
+    properties[:show_on_index].nil? || properties[:show_on_index]
   end
 
   # index refers to the index.html.haml template, nothing to do with DB.

--- a/lib/frontier/controller_action/strong_params_method.rb
+++ b/lib/frontier/controller_action/strong_params_method.rb
@@ -17,7 +17,7 @@ private
   end
 
   def strong_params_from_attributes(attributes)
-    attributes.map do |attribute_or_association|
+    attributes.select(&:show_on_form?).map do |attribute_or_association|
       attribute_or_association_as_strong_params(attribute_or_association)
     end
   end

--- a/lib/frontier/spec_support/object_attributes_assertion.rb
+++ b/lib/frontier/spec_support/object_attributes_assertion.rb
@@ -53,7 +53,7 @@ private
 
   def expectations_for_attributes
     # Show attributes first, so they will all be nested under the ModelName comment
-    attributes_and_associations_ordered_by_nested_last.collect do |attribute|
+    attributes_and_associations_ordered_by_nested_last.select(&:show_on_form?).collect do |attribute|
       expectation_for(attribute)
     end
   end

--- a/lib/frontier/spec_support/object_setup/associated_model_setup.rb
+++ b/lib/frontier/spec_support/object_setup/associated_model_setup.rb
@@ -11,7 +11,7 @@ class Frontier::SpecSupport::ObjectSetup::AssociatedModelSetup
   #   let(:params) { {address_id: address.id} }
   #
   def to_s
-    model_configuration.associations.map do |association|
+    model_configuration.associations.select(&:show_on_form?).map do |association|
       # Nested forms can have their own associations
       if association.is_nested?
         Frontier::SpecSupport::ObjectSetup::AssociatedModelSetup.new(association).to_s

--- a/lib/frontier/spec_support/object_setup/attributes_hash.rb
+++ b/lib/frontier/spec_support/object_setup/attributes_hash.rb
@@ -40,7 +40,7 @@ class Frontier::SpecSupport::ObjectSetup::AttributesHash
   # that can be rendered in the controller spec template.
   def to_hash
     hash = {}
-    model_configuration.attributes.each do |attribute|
+    model_configuration.attributes.select(&:show_on_form?).each do |attribute|
       if attribute.is_attribute?
         # name: "attributes[:name]"
         hash[attribute.name.to_sym] = "#{attributes_name}[#{attribute.as_symbol}]"

--- a/lib/frontier/spec_support/object_setup/attributes_setup.rb
+++ b/lib/frontier/spec_support/object_setup/attributes_setup.rb
@@ -23,7 +23,7 @@ private
   end
 
   def nested_attributes_lets
-    model_configuration.associations.select(&:is_nested?).map do |association|
+    model_configuration.associations.select(&:show_on_form?).select(&:is_nested?).map do |association|
       key            = "#{association.name}_attributes"
       attributes_for = Frontier::FactoryGirlSupport::AttributesFor.new(association).to_s
 

--- a/lib/generators/frontier_controller/templates/controller_spec.rb
+++ b/lib/generators/frontier_controller/templates/controller_spec.rb
@@ -29,6 +29,7 @@ describe <%= controller_name %> do
 
   describe 'POST create' do
     subject { post :create, <%= model_configuration.model_name %>: attributes }
+
     # params.require(<%= model_configuration.as_symbol %>) will raise an exception if the
     # attributes hash provided is blank, so we pass through a fake value to prevent this.
     let(:attributes) { {id: 666} }
@@ -80,6 +81,9 @@ describe <%= controller_name %> do
 
   describe 'POST update' do
     subject(:update_resource) { post :update, id: <%= model_configuration.model_name %>.id, <%= model_configuration.model_name %>: attributes }
+
+    # params.require(<%= model_configuration.as_symbol %>) will raise an exception if the
+    # attributes hash provided is blank, so we pass through a fake value to prevent this.
     let(:attributes) { {id: <%= model_configuration.model_name %>.id} }
     let(<%= model_configuration.as_symbol %>) { FactoryGirl.create(<%= model_configuration.as_symbol %>) }
 

--- a/lib/generators/frontier_crud_views/templates/_form.html.haml
+++ b/lib/generators/frontier_crud_views/templates/_form.html.haml
@@ -1,6 +1,6 @@
 = <%= Frontier::FormHeader.new(model_configuration).to_s %>
 
-<% model_configuration.attributes.each_with_index do |attribute, index| -%>
+<% model_configuration.attributes.select(&:show_on_form?).each_with_index do |attribute, index| -%>
 <% options = {} -%>
 <% options = {autofocus: true} if index.zero? -%>
 <%= render_with_indent(1, Frontier::Input::Factory.build_for(attribute).to_s(options)) %>

--- a/spec/lib/frontier/attribute_spec.rb
+++ b/spec/lib/frontier/attribute_spec.rb
@@ -94,6 +94,26 @@ describe Frontier::Attribute do
     end
   end
 
+  describe "#show_on_form?" do
+    subject { attribute.show_on_form? }
+
+    context "when show_on_form property is set" do
+      context "when show_on_form is true" do
+        let(:options) { {show_on_form: true} }
+        it { should eq(true) }
+      end
+
+      context "when show_on_form is false" do
+        let(:options) { {show_on_form: false} }
+        it { should eq(false) }
+      end
+    end
+
+    context "when show_on_form property is not set" do
+      it { should eq(true) }
+    end
+  end
+
   describe "#show_on_index?" do
     subject { attribute.show_on_index? }
 

--- a/spec/lib/frontier/controller_action/strong_params_method_spec.rb
+++ b/spec/lib/frontier/controller_action/strong_params_method_spec.rb
@@ -8,6 +8,33 @@ describe Frontier::ControllerAction::StrongParamsMethod do
       Frontier::ControllerAction::StrongParamsMethod.new(model_configuration)
     end
 
+    describe "omitting fields that are not on the form" do
+      let(:model_configuration) do
+        Frontier::ModelConfiguration.new({
+          test_model: {
+            attributes: {
+              charlie: {type: "string", show_on_form: false},
+              address: {type: "belongs_to", form_type: "select"},
+              bravo: {type: "string"},
+            }
+          }
+        })
+      end
+
+      let(:expected) do
+        raw = <<-STRING
+def strong_params_for_test_model
+  params.require(:test_model).permit([:address_id, :bravo])
+end
+STRING
+        raw.rstrip
+      end
+
+      it "renders the params on a single line" do
+        should eq(expected)
+      end
+    end
+
     context "a simple model" do
       context "with 3 or fewer attributes" do
         let(:model_configuration) do

--- a/spec/lib/frontier/spec_support/object_attributes_assertion_spec.rb
+++ b/spec/lib/frontier/spec_support/object_attributes_assertion_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Frontier::SpecSupport::ObjectAttributesAssertion do
 
   describe '#to_s' do
     subject { Frontier::SpecSupport::ObjectAttributesAssertion.new(model_configuration).to_s }
+
     let(:model_configuration) do
       Frontier::ModelConfiguration.new({
         model_name: {
@@ -19,6 +20,7 @@ RSpec.describe Frontier::SpecSupport::ObjectAttributesAssertion do
               }
             },
             name: {type: "string"},
+            omitted_attribute: {type: "string", show_on_form: false}
           }
         }
       })

--- a/spec/lib/frontier/spec_support/object_setup/associated_model_setup_spec.rb
+++ b/spec/lib/frontier/spec_support/object_setup/associated_model_setup_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Frontier::SpecSupport::ObjectSetup::AssociatedModelSetup do
               form_type: "inline",
               attributes: {
                 line_1: {type: "string"},
-                state: {type: "belongs_to", form_type: "select"}
+                state: {type: "belongs_to", form_type: "select"},
+                other_thing: {type: "belongs_to", form_type: "select", show_on_form: false}
               }
             },
             name: {type: "string"},

--- a/spec/lib/frontier/spec_support/object_setup/attributes_hash_spec.rb
+++ b/spec/lib/frontier/spec_support/object_setup/attributes_hash_spec.rb
@@ -5,6 +5,27 @@ RSpec.describe Frontier::SpecSupport::ObjectSetup::AttributesHash do
   describe "#to_hash" do
     subject { Frontier::SpecSupport::ObjectSetup::AttributesHash.new(model_configuration).to_hash }
 
+    describe "omitting fields that are not on the form" do
+      let(:model_configuration) do
+        Frontier::ModelConfiguration.new({
+          model_name: {
+            attributes: {
+              name: {type: "string"},
+              other_attribute: {type: "string", show_on_form: false},
+            }
+          }
+        })
+      end
+
+      let(:expected) do
+        {
+          name: "model_name_attributes[:name]"
+        }
+      end
+
+      it { should eq(expected) }
+    end
+
     context "with a simple set of attributes" do
       let(:model_configuration) do
         Frontier::ModelConfiguration.new({

--- a/spec/lib/frontier/spec_support/object_setup/attributes_setup_spec.rb
+++ b/spec/lib/frontier/spec_support/object_setup/attributes_setup_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Frontier::SpecSupport::ObjectSetup::AttributesSetup do
           model_name: {
             attributes: {
               address: {type: "belongs_to", form_type: form_type},
+              other_thing: {type: "belongs_to", form_type: "inline", show_on_form: false},
               name: {type: "string"},
             }
           }


### PR DESCRIPTION
Allow us to remove some attributes from the form. This is useful for nested objects where the model will have a Client, but can't set Client on the form.